### PR TITLE
Revert "sepolicy: let matlog read dmesg"

### DIFF
--- a/common/private/priv_app.te
+++ b/common/private/priv_app.te
@@ -1,3 +1,1 @@
 allow priv_app ota_package_file:dir create_dir_perms;
-
-allow priv_app kernel:system { syslog_read };


### PR DESCRIPTION
Hits neverallow in userbuild, remove it till we find a better solution

This reverts commit d873ad11d8c0446ea8af06291221f3e51a1db897.