### PR TITLE
Revert "common: Drop custom filesystem rules"

### DIFF
--- a/common/private/file.te
+++ b/common/private/file.te
@@ -1,2 +1,3 @@
+type sdcard_posix, sdcard_type, sdcard_posix_contextmount_type, fs_type, mlstrustedobject;
 type adbroot_data_file, file_type, data_file_type, core_data_file_type;
 type pocket_judge_sysfs, fs_type, sysfs_type;

--- a/common/private/file_contexts
+++ b/common/private/file_contexts
@@ -1,3 +1,9 @@
+# Filesystem tools
+/system/bin/fsck\.ntfs                  u:object_r:fsck_exec:s0
+/system/bin/mkfs\.exfat                 u:object_r:mkfs_exec:s0
+/system/bin/mkfs\.f2fs                  u:object_r:mkfs_exec:s0
+/system/bin/mkfs\.ntfs                  u:object_r:mkfs_exec:s0
+
 # OTA packages
 /data/lineageos_updates(/.*)?           u:object_r:ota_package_file:s0
 

--- a/common/private/fsck_untrusted.te
+++ b/common/private/fsck_untrusted.te
@@ -1,0 +1,2 @@
+# External storage
+allow fsck_untrusted self:capability sys_admin;

--- a/common/private/genfs_contexts
+++ b/common/private/genfs_contexts
@@ -1,1 +1,5 @@
+ifelse(board_excludes_fuseblk_sepolicy, `true', ,
+genfscon fuseblk / u:object_r:vfat:s0
+)
+
 genfscon sysfs /devices/virtual/timed_output/vibrator u:object_r:sysfs_vibrator:s0

--- a/common/private/mkfs.te
+++ b/common/private/mkfs.te
@@ -1,0 +1,9 @@
+type mkfs, coredomain, domain;
+type mkfs_exec, system_file_type, exec_type, file_type;
+
+init_daemon_domain(mkfs)
+
+# Allow formatting userdata or cache partitions
+allow mkfs block_device:dir search;
+allow mkfs userdata_block_device:blk_file rw_file_perms;
+allow mkfs cache_block_device:blk_file rw_file_perms;

--- a/common/private/system_server.te
+++ b/common/private/system_server.te
@@ -1,3 +1,5 @@
+allow system_server storage_stub_file:dir getattr;
+
 allow system_server adbroot_service:service_manager find;
 allow system_server pocket_service:service_manager { add find };
 allow system_server pocket_judge_sysfs:dir search;

--- a/common/private/vold.te
+++ b/common/private/vold.te
@@ -1,0 +1,11 @@
+# NTFS-3g wants to drop permission
+allow vold self:capability { setgid setuid };
+
+# External storage
+allow vold mkfs_exec:file rx_file_perms;
+allow vold mnt_media_rw_stub_file:dir r_dir_perms;
+allow vold storage_stub_file:dir rw_dir_perms;
+
+# External EXT4/F2FS storage
+allow vold sdcard_posix:filesystem { relabelto relabelfrom };
+allow vold labeledfs:filesystem relabelfrom;

--- a/common/sepolicy.mk
+++ b/common/sepolicy.mk
@@ -9,6 +9,12 @@ TARGET_USES_PREBUILT_VENDOR_SEPOLICY ?= true
 endif
 endif
 
+ifeq ($(TARGET_USES_PREBUILT_VENDOR_SEPOLICY), true)
+ifeq ($(TARGET_HAS_FUSEBLK_SEPOLICY_ON_VENDOR),true)
+BOARD_SEPOLICY_M4DEFS += board_excludes_fuseblk_sepolicy=true
+endif
+endif
+
 SYSTEM_EXT_PUBLIC_SEPOLICY_DIRS += \
     device/lineage/sepolicy/common/public
 


### PR DESCRIPTION
This reverts commit 033ec5dc4d2d3b20414c9efffd9e0d3215901f82.

Reason for revert: Needed for custom filesystem support

Change-Id: Ie7d24391f68bb854e53b78aa92d01c2c546a3089